### PR TITLE
Fixed a bug when non-ascii strings are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.history/
+*.pyc

--- a/ds_store_parser/ds_store/store.py
+++ b/ds_store_parser/ds_store/store.py
@@ -350,6 +350,14 @@ class DSStore(object):
     def _get_block(self, number):
         return self._store.get_block(number)
 
+    def _build_str_from_entry(self, entry):
+        chk = entry.filename.encode('utf-8', 'replace') + str(entry.type) + str(entry.code) + self.src_name.encode('utf-8', 'replace')
+        if entry.type == 'ustr':
+            chk += entry.value.encode('utf-8')
+        else:
+            chk += str(entry.value).encode('hex')
+        return chk
+
     # Iterate over the tree, starting at `node'
     def _traverse(self, node):
         counter = 0
@@ -369,13 +377,13 @@ class DSStore(object):
                         yield t
                     
                     e = DSStoreEntry.read(block, node)
-                    chk = e.filename.encode('ascii', 'replace') + str(e.type) + str(e.code) + self.src_name.encode('ascii', 'replace') + str(e.value).encode('hex')
+                    chk = self._build_str_from_entry(e)
                     e_hash = hashlib.md5(chk).hexdigest()
                     
                     if not self.dict_list.has_key(e_hash):
                         self.entries[e_hash] = e
                         self.entries[e_hash].node = 'allocated ' + str(node)
-                        self.dict_list[e_hash] = chk + 'allocated ' + str(node)
+                        self.dict_list[e_hash] = chk + 'allocated '.encode('utf-8') + str(node).encode('utf-8')
                         
                     elif self.dict_list.has_key(e_hash) and 'unallocated' in self.dict_list[e_hash]:
                         self.entries[e_hash] = e
@@ -402,13 +410,13 @@ class DSStore(object):
                 for n in range(count):
                     counter = counter + 1
                     e = DSStoreEntry.read(block, node)
-                    chk = e.filename.encode('ascii', 'replace') + str(e.type) + str(e.code) + self.src_name.encode('ascii', 'replace') + str(e.value).encode('hex')
+                    chk = self._build_str_from_entry(e)
                     e_hash = hashlib.md5(chk).hexdigest()
                     
                     if not self.dict_list.has_key(e_hash):
                         self.entries[e_hash] = e
                         self.entries[e_hash].node = 'allocated ' + str(node)
-                        self.dict_list[e_hash] = chk + 'allocated ' + str(node)
+                        self.dict_list[e_hash] = chk + 'allocated '.encode('utf-8') + str(node).encode('utf-8')
                         
                     elif self.dict_list.has_key(e_hash) and 'unallocated' in self.dict_list[e_hash]:
                         self.entries[e_hash] = e
@@ -509,7 +517,7 @@ class DSStore(object):
 
                     
                 e = DSStoreEntry(filename, code, typecode, value, 'unallocated')
-                chk = e.filename.encode('ascii', 'replace') + str(e.type) + str(e.code) + self.src_name.encode('ascii', 'replace') + str(e.value).encode('hex')
+                chk = self._build_str_from_entry(e)
                 e_hash = hashlib.md5(chk).hexdigest()
                 
                 if not self.dict_list.has_key(e_hash):


### PR DESCRIPTION
Fixed the problem that UnicodeEncodeError occurs when "e.value" in store.py has a non-ascii string, as shown below.
```
% python ./DSStoreParser.py -s ~/.Trash -o ~/Documents/GitHub/DSStoreParser_out
DS_Store Found:  /Users/macforensics/.Trash/.DS_Store
Traceback (most recent call last):
  File "./DSStoreParser.py", line 656, in <module>
    main()
  File "./DSStoreParser.py", line 182, in main
    parse(ds_file, file_io, stat_dict, record_handler, opts_source, opts_check)
  File "./DSStoreParser.py", line 270, in parse
    for rec in ds_handler:
  File "/Users/macforensics/Documents/GitHub/DSStoreParser/ds_store_parser/ds_store_handler.py", line 25, in __iter__
    for ds_store_entry in sorted(self.ds_store):
  File "/Users/macforensics/Documents/GitHub/DSStoreParser/ds_store_parser/ds_store/store.py", line 391, in _traverse
    for t in self._traverse(next_node):
  File "/Users/macforensics/Documents/GitHub/DSStoreParser/ds_store_parser/ds_store/store.py", line 391, in _traverse
    for t in self._traverse(next_node):
  File "/Users/macforensics/Documents/GitHub/DSStoreParser/ds_store_parser/ds_store/store.py", line 405, in _traverse
    chk = e.filename.encode('ascii', 'replace') + str(e.type) + str(e.code) + self.src_name.encode('ascii', 'replace') + str(e.value).encode('hex')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 22-26: ordinal not in range(128)
```
